### PR TITLE
Move postinstall script to prepack

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -19,7 +19,7 @@
     "prepare": "babel --extensions \".ts,.tsx\" --out-dir dist src",
     "lint": "npx eslint src",
     "test": "npx jest src",
-    "postinstall": "npx copyfiles \"./../README.md\" ./README.md"
+    "prepack": "npx copyfiles \"./../README.md\" ./README.md"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
Fixes https://github.com/callstack/react-native-slider/issues/430

Summary:
---------

Just replace `postinstall` with `prepack` as suggested in the issue comments

Test Plan:
----------

Can't really test as it seems it needs to be packed first? I tried pointing to my fork, but it complains 😅